### PR TITLE
Allow mode Secondary when connecting to Mongos

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -601,7 +601,7 @@ func (cluster *mongoCluster) AcquireSocket(mode Mode, slaveOk bool, syncTimeout 
 			mastersLen := cluster.masters.Len()
 			slavesLen := cluster.servers.Len() - mastersLen
 			debugf("Cluster has %d known masters and %d known slaves.", mastersLen, slavesLen)
-			if cluster.HasMongoS() || (!(slaveOk && mode == Secondary) && mastersLen > 0 || slaveOk && slavesLen > 0) {
+			if cluster.hasMongoS() || (!(slaveOk && mode == Secondary) && mastersLen > 0 || slaveOk && slavesLen > 0) {
 				break
 			}
 			if started.IsZero() {

--- a/server.go
+++ b/server.go
@@ -405,6 +405,15 @@ func (servers *mongoServers) Len() int {
 	return len(servers.slice)
 }
 
+func (servers *mongoServers) HasMongos() bool {
+	for _, s := range servers.slice {
+		if s.Info().Mongos {
+			return true
+		}
+	}
+	return false
+}
+
 func (servers *mongoServers) Empty() bool {
 	return len(servers.slice) == 0
 }
@@ -428,6 +437,8 @@ func (servers *mongoServers) BestFit(mode Mode, serverTags []bson.D) *mongoServe
 		switch {
 		case serverTags != nil && !next.info.Mongos && !next.hasTags(serverTags):
 			// Must have requested tags.
+		case mode == Secondary && next.info.Master && !next.info.Mongos:
+			// Must be a secondary or mongos.
 		case next.info.Master != best.info.Master && mode != Nearest:
 			// Prefer slaves, unless the mode is PrimaryPreferred.
 			swap = (mode == PrimaryPreferred) != best.info.Master


### PR DESCRIPTION
Irritatingly, I fixed this myself before noticing a very similar fix in the go-mgo/mgo repository.

So this is : https://github.com/go-mgo/mgo/commit/2451555cc2651b3754ebb21df4b34f47af971482

I wasn't entirely sure how to merge this directly into our fork, let me know the right way
