### PR TITLE
Release socket properly after reuse time has expired

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -62,6 +62,7 @@ type mongoCluster struct {
 	sync               chan bool
 	dial               dialer
 	maxSocketReuseTime time.Duration
+	poolLimit 	   int
 }
 
 func newCluster(userSeeds []string, direct, failFast bool, dial dialer, setName string, maxSocketReuseTime time.Duration) *mongoCluster {
@@ -580,7 +581,7 @@ func (cluster *mongoCluster) syncServersIteration(direct bool) {
 // AcquireSocket returns a socket to a server in the cluster.  If slaveOk is
 // true, it will attempt to return a socket to a slave server.  If it is
 // false, the socket will necessarily be to a master server.
-func (cluster *mongoCluster) AcquireSocket(mode Mode, slaveOk bool, syncTimeout time.Duration, socketTimeout time.Duration, serverTags []bson.D, poolLimit int) (s *mongoSocket, err error) {
+func (cluster *mongoCluster) AcquireSocket(mode Mode, slaveOk bool, syncTimeout time.Duration, socketTimeout time.Duration, serverTags []bson.D) (s *mongoSocket, err error) {
 	var started time.Time
 	var syncCount uint
 	warnedLimit := false
@@ -625,7 +626,7 @@ func (cluster *mongoCluster) AcquireSocket(mode Mode, slaveOk bool, syncTimeout 
 			continue
 		}
 
-		s, abended, err := server.AcquireSocket(poolLimit, socketTimeout)
+		s, abended, err := server.AcquireSocket(cluster.poolLimit, socketTimeout)
 		if err == errPoolLimit {
 			if !warnedLimit {
 				warnedLimit = true

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -1638,68 +1638,45 @@ func (s *S) TestPoolLimitMany(c *C) {
 	c.Assert(delay < 6e9, Equals, true)
 }
 
-func (s *S) TestMaxSocketUseTimeExpireAfterRelease(c *C) {
-	if *fast {
-		c.Skip("-fast")
-	}
-	session, err := mgo.Dial("localhost:40011?maxSocketReuseTimeSecs=2")
-	c.Assert(err, IsNil)
-	defer session.Close()
-
-	stats := mgo.GetStats()
-	for stats.SocketsAlive != 3 {
-		c.Logf("Waiting for all connections to be established (sockets alive currently %d)...", stats.SocketsAlive)
-		stats = mgo.GetStats()
-		time.Sleep(5e8)
-	}
-
-	session2 := session.Copy()
-	defer session2.Close()
-	c.Check(session2.Ping(), IsNil)
-	// refresh will return connection back so they can be recycled
-	session2.Refresh()
-	stats = mgo.GetStats()
-	// connection timeout not expired, we shouldnt expire any connections
-	c.Assert(stats.SocketsExpired, Equals, 0)
-	// wait for enough time to expire the connection
-	time.Sleep(2500 * time.Millisecond)
-	// request a connection, look for recycled connections first and make sure max life time
-	// for connection has not reached
-	c.Check(session2.Ping(), IsNil)
-	// timeout for connection life expired, we should see one connection expired
-	stats = mgo.GetStats()
-	c.Assert(stats.SocketsExpired, Equals, 1)
-}
-
 // test to ensure that expired sockets are removed from active sockets list
 func (s *S) TestSocketExpiryEnsureSocketClosed(c *C) {
 	var session *mgo.Session
 	var err error
 	session, err = mgo.Dial("localhost:40001?maxPoolSize=1&maxSocketReuseTimeSecs=1")
+
 	c.Assert(err, IsNil)
 	defer session.Close()
 
 	// Put one socket in use.
 	c.Assert(session.Ping(), IsNil)
 
-	done := make(chan time.Duration)
-
+	done := make(chan bool)
 	// Now block trying to get another one due to the pool limit.
 	go func() {
 		copy := session.Copy()
 		defer copy.Close()
-		started := time.Now()
 		c.Check(copy.Ping(), IsNil)
-		done <- time.Now().Sub(started)
+		done <- true
 	}()
 
-	// ensure that sockets is recycled after expiry time expired
+	// ensure that socket reuse expiry time expires
 	time.Sleep(time.Second)
 
-	// Put the one socket back in the pool, freeing it for the copy.
+	// Put the one socket back in the pool, freeing it for the copy session.
 	session.Refresh()
-	delay := <-done
-	c.Assert(delay > 300 * time.Millisecond, Equals, true, Commentf("Delay: %s", delay))
+	timer := time.NewTimer(time.Millisecond*100)
+	select {
+	// waits for copy session to get non-expired new socket
+	case <-done:
+		c.Assert(mgo.GetStats().SocketsExpired, Equals, 1)
+	case <-timer.C:
+		// didnt get socket from our pool of recycled sockets even after waiting
+		// increase the pool limit to break the loop
+		session.SetPoolLimit(2)
+		// give time to copy session finish its processing
+		<-done
+		c.Fail()
+	}
 }
 
 func (s *S) TestSetModeEventualIterBug(c *C) {

--- a/session.go
+++ b/session.go
@@ -297,6 +297,7 @@ func ParseURL(url string) (*DialInfo, error) {
 			if err != nil {
 				return nil, errors.New("bad value for maxSocketReuseTime: " + v)
 			}
+			debugf("using maxSocketReuseTimeSecs: %d", maxSocketReuseTimeSecs)
 		case "connect":
 			if v == "direct" {
 				direct = true

--- a/socket.go
+++ b/socket.go
@@ -232,8 +232,9 @@ func (socket *mongoSocket) InitialAcquire(serverInfo *mongoServerInfo, timeout t
 		stats.socketsExpired(+1)
 		debugf("socket: %p cannot use socket - max connection reuse time expired", socket)
 		socket.Unlock()
-		socket.Close()
-		return errors.New("Socket reuse time expired")
+		err := errors.New("Socket reuse time expired")
+		socket.kill(err, true)
+		return err
 	}
 	socket.references++
 	socket.serverInfo = serverInfo

--- a/socket.go
+++ b/socket.go
@@ -233,6 +233,7 @@ func (socket *mongoSocket) InitialAcquire(serverInfo *mongoServerInfo, timeout t
 		debugf("socket: %p cannot use socket - max connection reuse time expired", socket)
 		socket.Unlock()
 		err := errors.New("Socket reuse time expired")
+		// terminate the socket and cleanup all socket use counters
 		socket.kill(err, true)
 		return err
 	}

--- a/stats.go
+++ b/stats.go
@@ -28,6 +28,8 @@ package mgo
 
 import (
 	"sync"
+	"encoding/json"
+	"bytes"
 )
 
 var stats *Stats
@@ -77,6 +79,14 @@ type Stats struct {
 	SocketsInUse   int
 	SocketRefs     int
 	SocketsExpired int
+}
+
+// for mostly debugging purpose
+func (stats Stats) String() string {
+	val, _ := json.Marshal(stats)
+	var out bytes.Buffer
+	json.Indent(&out, val, "", "  ")
+	return string(out.Bytes())
 }
 
 func (stats *Stats) cluster(delta int) {


### PR DESCRIPTION
we enabled mongo socket expiry on auth yesterday and at around 7pm a page on high cpu utilization was fired. After inspecting thread stack trace it was evident that all goroutines were stuck on getting new socket method. This stack trace provided lot of information and lead to the fix. Close method on socket didnt properly cleanup the socket, and kept a reference of socket in list. Even though counters were updated and thats the reason it wasnt caught up in test code. I can repro it locally and I’m now writing test to properly exercise the code path.

see here - https://github.com/lyft/mgo/blob/v2-unstable/socket.go#L315, close method is passing abden as false which is preventing AbdenSocket method to be called which actually clears list https://github.com/lyft/mgo/blob/v2-unstable/server.go#L231

the new test TestSocketExpiryEnsureSocketClosed fails (blocks) without this new code change

TestSocketExpiryEnsureSocketClosed is forked from TestPoolLimitSimple

for go routine stack trace take a look at this link - https://lyft.slack.com/files/adil/F40G9LE7P/goroutine_auth_canary.txt