### PR TITLE
use active sock count to control limit on pool

### DIFF
--- a/server.go
+++ b/server.go
@@ -113,11 +113,11 @@ func (server *mongoServer) AcquireSocket(poolLimit int, timeout time.Duration) (
 			return nil, abended, errServerClosed
 		}
 
-		if poolLimit > 0 && server.activeSocketsCount > poolLimit {
+		unusedSocketsCount := len(server.unusedSockets)
+		if unusedSocketsCount == 0 && poolLimit > 0 && server.activeSocketsCount >= poolLimit {
 			server.Unlock()
 			return nil, false, errPoolLimit
 		}
-		unusedSocketsCount := len(server.unusedSockets)
 		if unusedSocketsCount > 0 {
 			socket = server.unusedSockets[unusedSocketsCount-1]
 			server.unusedSockets[unusedSocketsCount-1] = nil // Help GC.

--- a/server.go
+++ b/server.go
@@ -113,7 +113,7 @@ func (server *mongoServer) AcquireSocket(poolLimit int, timeout time.Duration) (
 			return nil, abended, errServerClosed
 		}
 
-		if poolLimit > 0 && server.activeSocketsCount >= poolLimit {
+		if poolLimit > 0 && server.activeSocketsCount > poolLimit {
 			server.Unlock()
 			return nil, false, errPoolLimit
 		}

--- a/socket.go
+++ b/socket.go
@@ -185,13 +185,12 @@ type requestInfo struct {
 	replyFunc replyFunc
 }
 
-func newSocket(server *mongoServer, socket *mongoSocket, conn net.Conn, timeout time.Duration, expiryTime *time.Time) *mongoSocket {
+func newSocket(server *mongoServer, socket *mongoSocket, conn net.Conn, timeout time.Duration, expiryTime *time.Time) {
 	socket.conn = conn
 	socket.addr = server.Addr
 	socket.server = server
 	socket.replyFuncs = make(map[uint32]replyFunc)
 	socket.expiryTime = expiryTime
-
 	socket.gotNonce.L = &socket.Mutex
 	if err := socket.InitialAcquire(server.Info(), timeout); err != nil {
 		panic("newSocket: InitialAcquire returned error: " + err.Error())
@@ -200,7 +199,6 @@ func newSocket(server *mongoServer, socket *mongoSocket, conn net.Conn, timeout 
 	debugf("Socket %p to %s: initialized", socket, socket.addr)
 	socket.resetNonce()
 	go socket.readLoop()
-	return socket
 }
 
 // Server returns the server that the socket is associated with.

--- a/socket.go
+++ b/socket.go
@@ -38,10 +38,10 @@ import (
 
 type replyFunc func(err error, reply *replyOp, docNum int, docData []byte)
 
-type ScoketState int
+type SocketState uint8
 const (
-	Connecting = 1
-	Connected = 2
+	Connecting SocketState = iota
+	Connected
 )
 
 type mongoSocket struct {
@@ -60,7 +60,7 @@ type mongoSocket struct {
 	dead          error
 	serverInfo    *mongoServerInfo
 	expiryTime    *time.Time // time in future when this socket should be expired
-	socketState   ScoketState
+	socketState   SocketState
 }
 
 type queryOpFlags uint32

--- a/suite_test.go
+++ b/suite_test.go
@@ -40,6 +40,7 @@ import (
 	. "gopkg.in/check.v1"
 	"github.com/lyft/mgo"
 	"github.com/lyft/mgo/bson"
+	"strings"
 )
 
 var fast = flag.Bool("fast", false, "Skip slow tests")
@@ -155,9 +156,12 @@ func (s *S) pid(host string) int {
 		panic(err)
 	}
 	pidstr := string(output[1 : len(output)-1])
+	if strings.Contains(pidstr, "\n") {
+		pidstr = string(pidstr[0 : strings.Index(pidstr, "\n")])
+	}
 	pid, err := strconv.Atoi(pidstr)
 	if err != nil {
-		panic("cannot convert pid to int: " + pidstr)
+		panic( fmt.Sprintf("cannot convert pid to int: . %s .", pidstr))
 	}
 	return pid
 }

--- a/suite_test.go
+++ b/suite_test.go
@@ -156,12 +156,13 @@ func (s *S) pid(host string) int {
 		panic(err)
 	}
 	pidstr := string(output[1 : len(output)-1])
+
 	if strings.Contains(pidstr, "\n") {
 		pidstr = string(pidstr[0 : strings.Index(pidstr, "\n")])
 	}
 	pid, err := strconv.Atoi(pidstr)
 	if err != nil {
-		panic( fmt.Sprintf("cannot convert pid to int: . %s .", pidstr))
+		panic("cannot convert pid to int: " + pidstr)
 	}
 	return pid
 }


### PR DESCRIPTION
While investigating socket timeout issue, we found out that we're opening more connections to mongo server than what we've set in poolLimit. It appears that mgo has a but under high load it can open lot more connections.

This code change attempts to put max limit on active connections to mongo server.