### PR TITLE
Better maintain socket alive count

### DIFF
--- a/socket.go
+++ b/socket.go
@@ -196,7 +196,6 @@ func newSocket(server *mongoServer, socket *mongoSocket, conn net.Conn, timeout 
 	if err := socket.InitialAcquire(server.Info(), timeout); err != nil {
 		panic("newSocket: InitialAcquire returned error: " + err.Error())
 	}
-	stats.socketsAlive(+1)
 	debugf("Socket %p to %s: initialized", socket, socket.addr)
 	socket.resetNonce()
 	go socket.readLoop()
@@ -351,7 +350,6 @@ func (socket *mongoSocket) kill(err error, abend bool) {
 	logf("Socket %p to %s: closing: %s (abend=%v)", socket, socket.addr, err.Error(), abend)
 	socket.dead = err
 	socket.conn.Close()
-	stats.socketsAlive(-1)
 	replyFuncs := socket.replyFuncs
 	socket.replyFuncs = make(map[uint32]replyFunc)
 	server := socket.server


### PR DESCRIPTION
There is a race condition between incrementing and decrementing the socketsAlive counter in mgo. We can see its evidence from socketsAlive graph in WF. The reason for high number of socketsAlive count comes because we convert a negative value into uint64 which converts into a humungous number - https://github.com/lyft/golyft/blob/master/mongo/mongo_client_stats.go#L57

Below WF graph shows huge number of sockets due to this consistency bug,

https://lyft.wavefront.com/u/B8gcyqshXw