### PR TITLE
add time based seed to random number generator

### DIFF
--- a/server.go
+++ b/server.go
@@ -201,9 +201,7 @@ func (server *mongoServer) Connect(timeout time.Duration, socket *mongoSocket) e
 	var socketExpiryTime *time.Time
 	if server.maxSocketReuseTime != 0 {
 		duration := server.maxSocketReuseTime
-		randomSource := rand.NewSource(time.Now().UnixNano())
-		random := rand.New(randomSource)		
-		durationWithJitter := time.Duration(float64(duration) * (1 + random.Float64()*socketExpiryJitterAmount))
+		durationWithJitter := time.Duration(float64(duration) * (1 + rand.Float64()*socketExpiryJitterAmount))
 		expiryTime := time.Now().Add(durationWithJitter)
 		socketExpiryTime = &expiryTime
 	}

--- a/server.go
+++ b/server.go
@@ -201,7 +201,9 @@ func (server *mongoServer) Connect(timeout time.Duration, socket *mongoSocket) e
 	var socketExpiryTime *time.Time
 	if server.maxSocketReuseTime != 0 {
 		duration := server.maxSocketReuseTime
-		durationWithJitter := time.Duration(float64(duration) * (1 + rand.Float64()*socketExpiryJitterAmount))
+		randomSource := rand.NewSource(time.Now().UnixNano())
+		random := rand.New(randomSource)		
+		durationWithJitter := time.Duration(float64(duration) * (1 + random.Float64()*socketExpiryJitterAmount))
 		expiryTime := time.Now().Add(durationWithJitter)
 		socketExpiryTime = &expiryTime
 	}

--- a/session.go
+++ b/session.go
@@ -42,6 +42,7 @@ import (
 	"time"
 
 	"github.com/lyft/mgo/bson"
+	"math/rand"
 )
 
 type Mode int
@@ -421,6 +422,7 @@ func (addr *ServerAddr) TCPAddr() *net.TCPAddr {
 
 // DialWithInfo establishes a new session to the cluster identified by info.
 func DialWithInfo(info *DialInfo) (*Session, error) {
+	rand.Seed(time.Now().UnixNano())
 	addrs := make([]string, len(info.Addrs))
 	for i, addr := range info.Addrs {
 		p := strings.LastIndexAny(addr, "]:")


### PR DESCRIPTION
We are seeing all connections on SpannerProxy closed every 30-40 minutes.  And then we are seeing large spikes in connection ratelimiting when we then try to reopen those connections.  This seems to indicate that all processes and machines are seeing their random number generator identically, which seems to be the default behavior from what I can tell of the Go rand package.  See https://golang.org/pkg/math/rand/#Seed
<pre>
If Seed is not called, the generator behaves as if seeded by Seed(1)
</pre>