### PR TITLE
Allow comments on findAndModify

### DIFF
--- a/session.go
+++ b/session.go
@@ -4154,12 +4154,14 @@ type Change struct {
 	Upsert    bool        // Whether to insert in case the document isn't found
 	Remove    bool        // Whether to remove the document found rather than updating
 	ReturnNew bool        // Should the modified document be returned rather than the old one
+	Comment   string      // Comment for findAndModify
 }
 
 type findModifyCmd struct {
 	Collection                  string      "findAndModify"
 	Query, Update, Sort, Fields interface{} ",omitempty"
 	Upsert, Remove, New         bool        ",omitempty"
+	Comment                     string      ",omitempty"
 }
 
 type valueResult struct {

--- a/session.go
+++ b/session.go
@@ -4219,6 +4219,7 @@ func (q *Query) Apply(change Change, result interface{}) (info *ChangeInfo, err 
 		Query:      op.query,
 		Sort:       op.options.OrderBy,
 		Fields:     op.selector,
+		Comment:    change.Comment,
 	}
 
 	session = session.Clone()

--- a/session_test.go
+++ b/session_test.go
@@ -1035,6 +1035,15 @@ func (s *S) TestFindAndModify(c *C) {
 	c.Assert(info.UpsertedId, IsNil)
 
 	result = M{}
+	info, err = coll.Find(M{"n": 44}).Apply(mgo.Change{Update: M{"n": 50, "o": 52}, Comment: "b"}, result)
+	c.Assert(err, IsNil)
+	c.Assert(result["n"], Equals, 50)
+	c.Assert(result["o"], Equals, 52)
+	c.Assert(info.Updated, Equals, 0)
+	c.Assert(info.Removed, Equals, 0)
+	c.Assert(info.UpsertedId, NotNil)
+
+	result = M{}
 	info, err = coll.Find(M{"n": 50}).Apply(mgo.Change{Upsert: true, Update: M{"n": 51, "o": 52}}, result)
 	c.Assert(err, IsNil)
 	c.Assert(result["n"], IsNil)


### PR DESCRIPTION
findAndModify has a different syntax with regard to Comments:

db.users.findAndModify( {
   query: { "_id": NumberLong("894907066851785440") },
   update: { $set: { currentRideId: 66 } },
   comment: "oh"
} );

we need to explicitly pass a comment in since the one on Get gets lost.