### PR TITLE
Revert "Better maintain socket alive count (#9)"

### DIFF
--- a/server.go
+++ b/server.go
@@ -138,7 +138,6 @@ func (server *mongoServer) AcquireSocket(poolLimit int, timeout time.Duration) (
 			}
 			// hold our spot in the liveSockets slice
 			server.liveSockets = append(server.liveSockets, socket)
-			stats.socketsAlive(+1)
 			server.Unlock()
 			// release server lock so we can initiate concurrent connections to mongodb
 			err = server.Connect(timeout, socket)
@@ -223,7 +222,6 @@ func (server *mongoServer) Close() {
 	server.Unlock()
 	logf("Connections to %s closing (%d live sockets).", server.Addr, len(liveSockets))
 	for i, s := range liveSockets {
-		stats.socketsAlive(-1)
 		s.Close()
 		liveSockets[i] = nil
 	}
@@ -263,7 +261,6 @@ func (server *mongoServer) AbendSocket(socket *mongoSocket) {
 		server.Unlock()
 		return
 	}
-	stats.socketsAlive(-1)
 	server.liveSockets = removeSocket(server.liveSockets, socket)
 	server.unusedSockets = removeSocket(server.unusedSockets, socket)
 	server.Unlock()

--- a/socket.go
+++ b/socket.go
@@ -196,6 +196,7 @@ func newSocket(server *mongoServer, socket *mongoSocket, conn net.Conn, timeout 
 	if err := socket.InitialAcquire(server.Info(), timeout); err != nil {
 		panic("newSocket: InitialAcquire returned error: " + err.Error())
 	}
+	stats.socketsAlive(+1)
 	debugf("Socket %p to %s: initialized", socket, socket.addr)
 	socket.resetNonce()
 	go socket.readLoop()
@@ -350,6 +351,7 @@ func (socket *mongoSocket) kill(err error, abend bool) {
 	logf("Socket %p to %s: closing: %s (abend=%v)", socket, socket.addr, err.Error(), abend)
 	socket.dead = err
 	socket.conn.Close()
+	stats.socketsAlive(-1)
 	replyFuncs := socket.replyFuncs
 	socket.replyFuncs = make(map[uint32]replyFunc)
 	server := socket.server


### PR DESCRIPTION
This reverts commit 855a617a1e04c71c1a6a2fe0a96c3a7a574cb528.