### PR TITLE
Raw payload support

### DIFF
--- a/session.go
+++ b/session.go
@@ -684,6 +684,24 @@ func (db *Database) Run(cmd interface{}, result interface{}) error {
 	return db.run(socket, cmd, result)
 }
 
+// RunRaw executes mongodb command prepared in caller according to
+// mongodb wired protocol and passed as payload.
+// It returns response recieved on socket back to caller.
+//
+// Wired protocol:
+//
+//     https://docs.mongodb.com/manual/reference/mongodb-wire-protocol
+//
+func (db *Database) RunRaw(payload []byte) (reply []byte, err error) {
+	socket, err := db.Session.acquireSocket(true)
+	if err != nil {
+		return nil, err
+	}
+	defer socket.Release()
+
+	return socket.QueryRaw(payload)
+}
+
 // Credential holds details to authenticate with a MongoDB server.
 type Credential struct {
 	// Username and Password hold the basic details for authentication.

--- a/socket.go
+++ b/socket.go
@@ -555,6 +555,58 @@ func (socket *mongoSocket) Query(ops ...interface{}) (err error) {
 	return err
 }
 
+func (socket *mongoSocket) QueryRaw(payload []byte) (data []byte, err error) {
+	// Buffer is ready for the pipe.  Lock, allocate ids, and enqueue.
+	socket.Lock()
+	if socket.dead != nil {
+		dead := socket.dead
+		socket.Unlock()
+		debugf("(QueryRaw)Socket %p to %s: failing query, already closed: %s", socket, socket.addr, socket.dead.Error())
+		return nil, dead
+	}
+
+	requestId := socket.nextRequestId + 1
+	if requestId == 0 {
+		requestId++
+	}
+
+	socket.nextRequestId = requestId + 1
+	setInt32(payload, 4, int32(requestId))
+
+	var wait, change sync.Mutex
+	var replyDone bool
+	var replyData []byte
+	var replyErr error
+	wait.Lock()
+	socket.replyFuncs[requestId] = func(err error, reply *replyOp, docNum int, docData []byte) {
+		change.Lock()
+		if !replyDone {
+			replyDone = true
+			replyErr = err
+			if err == nil {
+				replyData = docData
+			}
+		}
+		change.Unlock()
+		wait.Unlock()
+	}
+
+	debugf("(QueryRaw)Socket %p to %s: sending %d op(s) (%d bytes)", socket, socket.addr, 1, len(payload))
+	stats.sentOps(1)
+
+	socket.updateDeadline(writeDeadline)
+	_, err = socket.conn.Write(payload)
+	socket.Unlock()
+
+	wait.Lock()
+	change.Lock()
+	data = replyData
+	err = replyErr
+	change.Unlock()
+
+	return data, err
+}
+
 func fill(r net.Conn, b []byte) error {
 	l := len(b)
 	n, err := r.Read(b)

--- a/socket.go
+++ b/socket.go
@@ -571,6 +571,10 @@ func (socket *mongoSocket) QueryRaw(payload []byte) (data []byte, err error) {
 	}
 
 	socket.nextRequestId = requestId + 1
+	// request ID always start at 4th byte in payload according to
+	// mongodb wired protocol
+	// Although we could just use request IDs from original payload
+	// but better to just use own request IDs
 	setInt32(payload, 4, int32(requestId))
 
 	var wait, change sync.Mutex


### PR DESCRIPTION
We want to implement a shadow service which will receive mongo requests and shadow service will work as a passthrough proxy to pass those requests to shadow mongo cluster.
This way we'll be able to use mongo driver connection management as other production clusters use it, and we'll not need to touch mongo payload.