### PR TITLE
Handle multiple documents in response.

### DIFF
--- a/socket.go
+++ b/socket.go
@@ -335,7 +335,7 @@ func (socket *mongoSocket) Close() {
 func (socket *mongoSocket) kill(err error, abend bool) {
 	socket.Lock()
 	if socket.dead != nil {
-		logf("Socket %p to %s: killed again: %s (previously: %s)", socket, socket.addr, err.Error(), socket.dead.Error())
+		debugf("Socket %p to %s: killed again: %s (previously: %s)", socket, socket.addr, err.Error(), socket.dead.Error())
 		socket.Unlock()
 		return
 	}

--- a/socket.go
+++ b/socket.go
@@ -644,7 +644,6 @@ func (socket *mongoSocket) readLoop() {
 	s := make([]byte, 4)
 	conn := socket.conn // No locking, conn never changes.
 	for {
-		debugf("Socket %p ReplyFuncs: %d", socket, len(socket.replyFuncs))
 		err := fill(conn, p)
 		if err != nil {
 			debugf("Killing socket: %p because of error: %v", socket, err)
@@ -678,6 +677,7 @@ func (socket *mongoSocket) readLoop() {
 		stats.receivedDocs(int(reply.replyDocs))
 
 		socket.Lock()
+		debugf("Socket %p ReplyFuncs: %d", socket, len(socket.replyFuncs))
 		replyFunc, ok := socket.replyFuncs[uint32(responseTo)]
 		if ok {
 			delete(socket.replyFuncs, uint32(responseTo))

--- a/socket.go
+++ b/socket.go
@@ -657,7 +657,7 @@ func (socket *mongoSocket) readLoop() {
 
 		// Don't use socket.server.Addr here.  socket is not
 		// locked and socket.server may go away.
-		logf("Socket %p to %s: got reply (%d bytes) - Responseto: %d", socket, socket.addr, totalLen, responseTo)
+		debugf("Socket %p to %s: got reply (%d bytes) - Responseto: %d", socket, socket.addr, totalLen, responseTo)
 
 		_ = totalLen
 

--- a/socket.go
+++ b/socket.go
@@ -578,17 +578,8 @@ func (socket *mongoSocket) QueryRaw(payload []byte) (data []byte, err error) {
 	// but better to just use own request IDs
 	setInt32(payload, 4, int32(requestId))
 
-	// Below synchronization code is copied from SimpleQuery
-	// replyFunc is executed as a callback when data is read back from socket
-	// after writing payload to socket. wait and change mutex's serve purpose of
-	// making sure that data is read from socket before copying data for return from buffer.
-	//
-	// wait mutex is captured in anonymous function. Anonymous function unlocks wait mutex
-	// after it has done copying data from callback parameters (socket response).
-	// Actual query function will wait until this exchange has happened.
-	//var wait sync.Mutex
-	//var change sync.Mutex
-	//var replyDone bool
+	// replyFunc is executed as a callback for each document when data is read back from socket
+	// After writing payload to socket, it waits for execution of replyFunc to finish for all documents
 	var replyData []byte
 	var replyErr error
 

--- a/socket.go
+++ b/socket.go
@@ -644,7 +644,7 @@ func (socket *mongoSocket) readLoop() {
 	s := make([]byte, 4)
 	conn := socket.conn // No locking, conn never changes.
 	for {
-		logf("Socket %p ReplyFuncs: %d", socket, len(socket.replyFuncs))
+		debugf("Socket %p ReplyFuncs: %d", socket, len(socket.replyFuncs))
 		err := fill(conn, p)
 		if err != nil {
 			debugf("Killing socket: %p because of error: %v", socket, err)

--- a/socket.go
+++ b/socket.go
@@ -557,6 +557,7 @@ func (socket *mongoSocket) Query(ops ...interface{}) (err error) {
 
 func (socket *mongoSocket) QueryRaw(payload []byte) (data []byte, err error) {
 	// Buffer is ready for the pipe.  Lock, allocate ids, and enqueue.
+	debugf("(QueryRaw)Socket %p to %s.", socket, socket.addr)
 	socket.Lock()
 	if socket.dead != nil {
 		dead := socket.dead
@@ -592,18 +593,36 @@ func (socket *mongoSocket) QueryRaw(payload []byte) (data []byte, err error) {
 	wait.Lock()
 	socket.replyFuncs[requestId] = func(err error, reply *replyOp, docNum int, docData []byte) {
 		change.Lock()
-		if !replyDone {
+		shouldStop := false
+		if err != nil {
+			shouldStop = true
+		} else if reply == nil || reply.replyDocs == 0 {
+			shouldStop = true
+		} else if docNum == int(reply.replyDocs) - 1 {
+			// last document, no more replyFunc call expected.
+			shouldStop = true
+		}
+
+		if shouldStop && replyDone {
+			panic("Reply was already marked done.")
+		}
+
+		if err == nil && docData != nil && len(docData) >0 {
+			replyData = append(replyData, docData...)
+		}
+
+		if shouldStop {
 			replyDone = true
 			replyErr = err
-			if err == nil {
-				replyData = docData
-			}
 		}
+
 		change.Unlock()
-		wait.Unlock()
+		if shouldStop {
+			wait.Unlock()
+		}
 	}
 
-	debugf("(QueryRaw)Socket %p to %s: sending %d op(s) (%d bytes)", socket, socket.addr, 1, len(payload))
+	debugf("(QueryRaw)Socket %p to %s: sending %d op(s) (%d bytes) - RequestID: %d", socket, socket.addr, 1, len(payload), requestId)
 	stats.sentOps(1)
 
 	socket.updateDeadline(writeDeadline)
@@ -617,6 +636,8 @@ func (socket *mongoSocket) QueryRaw(payload []byte) (data []byte, err error) {
 	data = replyData
 	err = replyErr
 	change.Unlock()
+
+	debugf("Socket.QueryRaw complete %p", socket)
 
 	return data, err
 }
@@ -651,7 +672,7 @@ func (socket *mongoSocket) readLoop() {
 
 		// Don't use socket.server.Addr here.  socket is not
 		// locked and socket.server may go away.
-		debugf("Socket %p to %s: got reply (%d bytes)", socket, socket.addr, totalLen)
+		debugf("Socket %p to %s: got reply (%d bytes) - Responseto: %d", socket, socket.addr, totalLen, responseTo)
 
 		_ = totalLen
 
@@ -676,7 +697,6 @@ func (socket *mongoSocket) readLoop() {
 			delete(socket.replyFuncs, uint32(responseTo))
 		}
 		socket.Unlock()
-
 		if replyFunc != nil && reply.replyDocs == 0 {
 			replyFunc(nil, &reply, -1, nil)
 		} else {


### PR DESCRIPTION
We needed to handle situations when there were multiple documents in response in QueryRaw. We have to wait for until we are done with all documents.