### PR TITLE
Capture when mongoSocket.conn is nil to prevent panics

### DIFF
--- a/server.go
+++ b/server.go
@@ -28,6 +28,7 @@ package mgo
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"sort"
 	"sync"
@@ -198,6 +199,14 @@ func (server *mongoServer) Connect(timeout time.Duration, socket *mongoSocket) e
 		logf("Connection to %s failed: %v", server.Addr, err.Error())
 		return err
 	}
+
+	if conn == nil {
+		// if a dialer is incorrectly implemented, it may return (nil, nil)
+		// which will cause a panic downstream
+		logf("Received nil connection to %s", server.Addr)
+		return fmt.Errorf("received nil connection to %s", server.Addr)
+	}
+
 	logf("Connection to %s established.", server.Addr)
 
 	stats.conn(+1, master)

--- a/socket.go
+++ b/socket.go
@@ -350,7 +350,9 @@ func (socket *mongoSocket) kill(err error, abend bool) {
 
 	logf("Socket %p to %s: closing: %s (abend=%v)", socket, socket.addr, err.Error(), abend)
 	socket.dead = err
-	socket.conn.Close()
+	if socket.conn != nil {
+		socket.conn.Close()
+	}
 	stats.socketsAlive(-1)
 	replyFuncs := socket.replyFuncs
 	socket.replyFuncs = make(map[uint32]replyFunc)


### PR DESCRIPTION
Panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x942be1]

goroutine 48601425 [running]:
<redacted>/vendor/github.com/lyft/mgo.(*mongoSocket).kill(0xc002c95e00, 0x13da480, 0xc0028cd3f0, 0xc000bd8d00)
      /usr/local/workspace/src/<redacted>/vendor/github.com/lyft/mgo/socket.go:353 +0x241
<redacted>/vendor/github.com/lyft/mgo.(*mongoSocket).Close(0xc002c95e00)
      /usr/local/workspace/src/<redacted>/vendor/github.com/lyft/mgo/socket.go:332 +0x71
<redacted>/vendor/github.com/lyft/mgo.(*mongoServer).Close(0xc002f20000)
      /usr/local/workspace/src/<redacted>/vendor/github.com/lyft/mgo/server.go:228 +0x16f
<redacted>/vendor/github.com/lyft/mgo.(*mongoCluster).removeServer(0xc000246d80, 0xc002f20000)
      /usr/local/workspace/src/<redacted>/vendor/github.com/lyft/mgo/cluster.go:129 +0xb2
<redacted>/vendor/github.com/lyft/mgo.(*mongoCluster).syncServersIteration.func1.1(0xc00387a990, 0xc00019b234, 0xf, 0xc00387a9a0, 0x0, 0xc000922510, 0xc000246d80, 0xc000922540, 0xc000922570, 0x0, ...)
      /usr/local/workspace/src/<redacted>/vendor/github.com/lyft/mgo/cluster.go:524 +0x405
created by <redacted>/vendor/github.com/lyft/mgo.(*mongoCluster).syncServersIteration.func1
      /usr/local/workspace/src/<redacted>/vendor/github.com/lyft/mgo/cluster.go:494 +0x154
```

Tracing this down assuming sourcegraph is exhaustive:
- [NPE accessing `socket.conn`](https://github.com/lyft/mgo/blob/v2.5.1/socket.go#L353)
- only place that writes into that field is [`newSocket`](https://github.com/lyft/mgo/blob/v2.5.1/socket.go#L190)
- which is only called from the exported [`Connect`](https://github.com/lyft/mgo/blob/v2.5.1/server.go#L211) where the connection is dialed

Looking at the dial logic in `Connect`, it chooses between the stdlib, or one a new/old dialer. The only way conn could be nil is if the dialers return (nil, nil), which should only happen on a bad custom dialer implementation. The code that encountered this does not specify a custom dialer and is likely using the stdlib dialer, which should never return (nil, nil). Adding a nil check here just to be safe. As connections should be long-lived, I'd expect this change to be negligible performance-wise.

And, treating the symptom, also doing a nil check on `socket.conn` in the `kill` method.