### PR TITLE
DS-4992 - Fix race in mongoServer.Close()

### DIFF
--- a/server.go
+++ b/server.go
@@ -227,8 +227,12 @@ func (server *mongoServer) Connect(timeout time.Duration, socket *mongoSocket) e
 func (server *mongoServer) Close() {
 	server.Lock()
 	server.closed = true
-	liveSockets := server.liveSockets
-	unusedSockets := server.unusedSockets
+	// Copy the socket lists since other code paths such as removeSocket() will in-place modify
+	// them.
+	liveSockets := make([]*mongoSocket, len(server.liveSockets))
+	copy(liveSockets, server.liveSockets)
+	unusedSockets := make([]*mongoSocket, len(server.unusedSockets))
+	copy(unusedSockets, server.unusedSockets)
 	server.liveSockets = nil
 	server.unusedSockets = nil
 	server.Unlock()


### PR DESCRIPTION
As discussed [here](https://github.com/lyft/mgo/pull/38#issuecomment-492077746) @charlievieth noted a race condition. `Close()` attempts to copy state it wants while under lock, only to then release the lock and close underlying sockets. However, concurrent code paths may reach `removeSocket()` and cause modification of the slices which were't copied (only aliased) while the lock was held.

By making an actual copy under the lock, we avoid this problem without adding additional complexity.