### PR TITLE
Fix a race that can occur while closing a socket that is connecting

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -62,6 +62,12 @@ type mongoCluster struct {
 	sync               chan bool
 	dial               dialer
 	maxSocketReuseTime time.Duration
+	// The maximum number of sockets connected to the same server in a cluster. If the limit is reached for a server,
+	// the attempt to establish the connection will fail (not block).
+	//
+	// The purpose of the pool limit is primarily to protect the mongo cluster itself. Connections are expensive on
+	// the server (thread-per-connection), and the failure modes of a mongo cluster once you begin hitting connection
+	// limits can be catastrophic.
 	poolLimit          int
 	minPoolSize        int
 }

--- a/server.go
+++ b/server.go
@@ -143,7 +143,7 @@ func (server *mongoServer) AcquireSocket(poolLimit int, minPoolSize int, timeout
 				socketState: Connecting,
 			}
 			// hold a spot in the liveSockets slice to ensure connecting sockets are counted
-			// against the total connection cap.
+			// against the pool limit.
 			server.liveSockets = append(server.liveSockets, nil)
 			server.Unlock()
 			// release server lock so we can initiate concurrent connections to mongodb


### PR DESCRIPTION
Previously, this code used a non-nil socket as a placeholder in server.AcquireSocket.  This could lead to a race if server.Close is called while a socket is connecting.  This commit changes the code to use a nil socket placeholder instead.  If the socket successfully connects the nil-placeholder is replaced with the valid socket and removes the nil-placeholder if the socket fails to connect.

This is a follow on to https://github.com/lyft/mgo/pull/40 and fixes the race identified [here](https://github.com/lyft/mgo/pull/38#issuecomment-492077746).