### PR TITLE
Dont try to unmarshal if there is nothing to unmarshal

### DIFF
--- a/bson/bson.go
+++ b/bson/bson.go
@@ -558,6 +558,9 @@ func Unmarshal(in []byte, out interface{}) (err error) {
 // See the Unmarshal function documentation for more details on the
 // unmarshalling process.
 func (raw Raw) Unmarshal(out interface{}) (err error) {
+	if len(raw.Data) == 0 {
+		return SetZero
+	}
 	defer handleErr(&err)
 	v := reflect.ValueOf(out)
 	switch v.Kind() {


### PR DESCRIPTION
The unmarshaller ends up creating empty structs for the out parameter even when there is no data to unmarshal. This leads to bugs where you dont read your own write. This fixes that.